### PR TITLE
Update FindPath in 2D version

### DIFF
--- a/Assets/Scripts2D/DungeonPathfinder2D.cs
+++ b/Assets/Scripts2D/DungeonPathfinder2D.cs
@@ -90,8 +90,8 @@ public class DungeonPathfinder2D {
                     neighbor.Previous = node;
                     neighbor.Cost = newCost;
 
-                    if (queue.TryGetPriority(node, out float existingPriority)) {
-                        queue.UpdatePriority(node, newCost);
+                    if (queue.TryGetPriority(neighbor, out float existingPriority)) {
+                        queue.UpdatePriority(neighbor, newCost);
                     } else {
                         queue.Enqueue(neighbor, neighbor.Cost);
                     }


### PR DESCRIPTION
This might also be an issue in 3D, but I haven't tested it. When we calculate a path to a neighbor, we either need to update that neighbor's cost, or add it to the queue. The old code seems to try and update the cost of the current node instead of the neighbor, which does not seem right? It also very rarely causes a path to not be found, even though it exists and the end node was visited as a neighbor but never added to the queue. 